### PR TITLE
Update displayProductPriceBlock.tpl

### DIFF
--- a/eu_legal/views/templates/hook/displayProductPriceBlock.tpl
+++ b/eu_legal/views/templates/hook/displayProductPriceBlock.tpl
@@ -65,9 +65,6 @@
 			</div>
 			{/if}
 		</span>
-        {if isset($product.id_product_attribute) && $product.id_product_attribute > 0}
-            <span class="fromprice-info eu-legal">{l s='From' mod='eu_legal'}</span>
-        {/if}
 	{/if}
 	
 


### PR DESCRIPTION
I deleted this bug. Without any proof if there are difference between prices this if-clause doesn't make sense, because especially product details are absolutely the wrong place for this. And this if-clause in particular just displays "AB" in capital letters - and not even a price range.